### PR TITLE
Fix typo in varepsilon

### DIFF
--- a/tours/nonlinear_problems/linear_viscoelasticity_jax/linear_viscoelasticity_jax.md
+++ b/tours/nonlinear_problems/linear_viscoelasticity_jax/linear_viscoelasticity_jax.md
@@ -449,7 +449,7 @@ for i, dti in enumerate(np.diff(time_steps)):
 We check that the solution we obtain corresponds to the exact solution of the recovery test given by:
 
 $$\begin{align*}
-\epsv_{yy}(t) &= \varpeislon_r(1- \exp(-t/\tau))\\
+\epsv_{yy}(t) &= \varepsilon_r(1- \exp(-t/\tau))\\
 \sigma_{yy}(t) &= E_0\varepsilon_r + E_1\varepsilon_r \exp(-t/\tau)
 \end{align*}$$
 

--- a/tours/nonlinear_problems/linear_viscoelasticity_jax/linear_viscoelasticity_jax.py
+++ b/tours/nonlinear_problems/linear_viscoelasticity_jax/linear_viscoelasticity_jax.py
@@ -440,7 +440,7 @@ for i, dti in enumerate(np.diff(time_steps)):
 # We check that the solution we obtain corresponds to the exact solution of the recovery test given by:
 #
 # $$\begin{align*}
-# \epsv_{yy}(t) &= \varpeislon_r(1- \exp(-t/\tau))\\
+# \epsv_{yy}(t) &= \varepsilon_r(1- \exp(-t/\tau))\\
 # \sigma_{yy}(t) &= E_0\varepsilon_r + E_1\varepsilon_r \exp(-t/\tau)
 # \end{align*}$$
 


### PR DESCRIPTION
Fixing small typo in equation

![Screenshot 2024-04-11 at 13 37 17](https://github.com/bleyerj/comet-fenicsx/assets/2010323/bf429142-5df4-4153-bfc8-e4be1dfcabf1)
